### PR TITLE
Fix degreesToDMS minute boundary rounding bug

### DIFF
--- a/deg-conv.test.ts
+++ b/deg-conv.test.ts
@@ -52,6 +52,16 @@ test('W Longitude', () => {
   expect(DMSToDegrees('W172 30 00')).toBe(-172.5)
 })
 
+test('degreesToDMS minute boundaries', () => {
+  // Without Math.floor on minutes, 43.999 rounded to "43 60 -0.0 N" (invalid).
+  expect(degreesToDMS(43.999, true)).toBe('43 59 56.4 N')
+  // 43.508333... ≈ 43°30'30" — naive rounding produced "43 31 -0.0 N".
+  expect(degreesToDMS(43.508333, true)).toBe('43 30 30.0 N')
+  expect(degreesToDMS(43.5, true)).toBe('43 30 0.0 N')
+  expect(degreesToDMS(0, false)).toBe('0 0 0.0 E')
+  expect(degreesToDMS(-43.508333, false)).toBe('43 30 30.0 W')
+})
+
 test('Latitude Range', () => {
   expect(DMSToDegrees('000 00 00 E')).toBe(0)
   expect(DMSToDegrees('000 59 00 E')).toBe(59 / 60)

--- a/deg-conv.ts
+++ b/deg-conv.ts
@@ -57,8 +57,9 @@ export function degreesToDMS(degs: number, lat: boolean): string {
     dir = lat ? 'N' : 'E'
   }
   const d = Math.floor(degs)
-  const mins: number = Number(((degs - d) * 60).toFixed(0))
-  const secs = (degs - d - mins / 60).toFixed(1)
+  const totalMins = (degs - d) * 60
+  const mins = Math.floor(totalMins)
+  const secs = ((totalMins - mins) * 60).toFixed(1)
 
   return d + ' ' + mins + ' ' + secs + ' ' + dir
 }


### PR DESCRIPTION
## Description

Replace toFixed(0) on minutes with Math.floor so values just under a minute boundary no longer yield "60" minutes or negative seconds. Compute seconds from the remainder of the minute calculation rather than re-deriving from the rounded minutes.

Before: degreesToDMS(43.999, true)    -> "43 60 -0.0 N"
        degreesToDMS(43.508333, true) -> "43 31 -0.0 N"
After:  "43 59 56.4 N" and "43 30 30.0 N"

## Summary by Sourcery

Fix degree-to-DMS conversion around minute boundaries to avoid invalid minute and second values.

Bug Fixes:
- Correct degree-to-DMS conversion so values near minute boundaries no longer produce 60 minutes or negative seconds.

Tests:
- Add regression tests covering degree-to-DMS conversions at minute boundaries and for positive and negative coordinates.