### PR TITLE
Validate input range in degreesToDM/degreesToDMS

### DIFF
--- a/deg-conv.test.ts
+++ b/deg-conv.test.ts
@@ -52,6 +52,24 @@ test('W Longitude', () => {
   expect(DMSToDegrees('W172 30 00')).toBe(-172.5)
 })
 
+test('formatters reject out-of-range values', () => {
+  expect(() => degreesToDM(91, true)).toThrow(RangeError)
+  expect(() => degreesToDM(-91, true)).toThrow(RangeError)
+  expect(() => degreesToDMS(91, true)).toThrow(RangeError)
+  expect(() => degreesToDMS(-91, true)).toThrow(RangeError)
+  expect(() => degreesToDM(181, false)).toThrow(RangeError)
+  expect(() => degreesToDM(-181, false)).toThrow(RangeError)
+  expect(() => degreesToDMS(181, false)).toThrow(RangeError)
+  expect(() => degreesToDMS(-181, false)).toThrow(RangeError)
+  expect(() => degreesToDM(NaN, true)).toThrow(RangeError)
+  expect(() => degreesToDM(Infinity, false)).toThrow(RangeError)
+  // Boundaries are inclusive.
+  expect(() => degreesToDM(90, true)).not.toThrow()
+  expect(() => degreesToDM(-90, true)).not.toThrow()
+  expect(() => degreesToDM(180, false)).not.toThrow()
+  expect(() => degreesToDM(-180, false)).not.toThrow()
+})
+
 test('degreesToDMS minute boundaries', () => {
   // Without Math.floor on minutes, 43.999 rounded to "43 60 -0.0 N" (invalid).
   expect(degreesToDMS(43.999, true)).toBe('43 59 56.4 N')

--- a/deg-conv.ts
+++ b/deg-conv.ts
@@ -1,4 +1,15 @@
+function assertInRange(degs: number, lat: boolean): void {
+  if (!Number.isFinite(degs)) {
+    throw new RangeError('degrees must be a finite number')
+  }
+  const limit = lat ? 90 : 180
+  if (degs < -limit || degs > limit) {
+    throw new RangeError(`degrees ${degs} out of range for ${lat ? 'latitude (±90)' : 'longitude (±180)'}`)
+  }
+}
+
 export function degreesToDM(degs: number, lat: boolean): string {
+  assertInRange(degs, lat)
   let dir = ''
   if (degs < 0) {
     degs *= -1
@@ -49,6 +60,7 @@ export function DMToDegrees(DM: string): number {
 }
 
 export function degreesToDMS(degs: number, lat: boolean): string {
+  assertInRange(degs, lat)
   let dir = ''
   if (degs < 0) {
     degs *= -1


### PR DESCRIPTION
## Description

Both formatters previously accepted any finite (or non-finite) number and produced nonsense like "91 0.000 N". Throw RangeError for values outside ±90 (latitude) or ±180 (longitude), and for NaN/Infinity. Boundary values are accepted.

## Summary by Sourcery

Validate degree-to-DM/DMS formatters only accept finite latitude/longitude values within their respective ranges.

Bug Fixes:
- Reject out-of-range latitude and longitude values in degreesToDM and degreesToDMS by throwing RangeError for invalid inputs, including NaN and Infinity.

Tests:
- Add unit tests covering out-of-range, non-finite, and boundary values for degreesToDM and degreesToDMS formatters.