### PR TITLE
Reject DMS strings with multiple direction letters

### DIFF
--- a/deg-conv.test.ts
+++ b/deg-conv.test.ts
@@ -52,6 +52,15 @@ test('W Longitude', () => {
   expect(DMSToDegrees('W172 30 00')).toBe(-172.5)
 })
 
+test('DMSToDegrees rejects multiple direction letters', () => {
+  // Previously: includes()/replace() removed only the first letter,
+  // silently accepting "N43 30 N" or "43 30 N S" as 43.5.
+  expect(() => DMSToDegrees('N43 30 N')).toThrow(SyntaxError)
+  expect(() => DMSToDegrees('43 30 N S')).toThrow(SyntaxError)
+  expect(() => DMSToDegrees('S 43 30 W')).toThrow(SyntaxError)
+  expect(() => DMSToDegrees('43 30 EE')).toThrow(SyntaxError)
+})
+
 test('formatters reject out-of-range values', () => {
   expect(() => degreesToDM(91, true)).toThrow(RangeError)
   expect(() => degreesToDM(-91, true)).toThrow(RangeError)

--- a/deg-conv.ts
+++ b/deg-conv.ts
@@ -24,18 +24,18 @@ export function degreesToDM(degs: number, lat: boolean): string {
 }
 
 export function DMSToDegrees(DMS: string): number {
+  const dirMatches = DMS.match(/[NSEW]/g)
+  if (dirMatches && dirMatches.length > 1) {
+    throw new SyntaxError(`DMS string contains multiple direction letters: ${DMS}`)
+  }
   let negative = false
   let DMS_no_dir = DMS
-  if (DMS.includes('N')) {
-    DMS_no_dir = DMS.replace('N', '')
-  } else if (DMS.includes('S')) {
+  const dir = dirMatches?.[0]
+  if (dir === 'S' || dir === 'W') {
     negative = true
-    DMS_no_dir = DMS.replace('S', '')
-  } else if (DMS.includes('E')) {
-    DMS_no_dir = DMS.replace('E', '')
-  } else if (DMS.includes('W')) {
-    negative = true
-    DMS_no_dir = DMS.replace('W', '')
+  }
+  if (dir) {
+    DMS_no_dir = DMS.replace(dir, '')
   }
   const parts = DMS_no_dir.split(' ')
   let fract = 1


### PR DESCRIPTION
## Description

The original includes/replace pair stripped only the first matching N/S/E/W and silently accepted strings like "N43 30 N" or "43 30 N S" as valid (returning the absolute parse). Match all direction letters up front and throw SyntaxError when more than one is present.

## Summary by Sourcery

Validate DMS strings for multiple direction letters and ensure invalid inputs are rejected with a syntax error.

Bug Fixes:
- Prevent DMSToDegrees from silently accepting DMS strings containing multiple direction letters by throwing a SyntaxError instead.

Tests:
- Add unit tests to verify DMSToDegrees throws SyntaxError when DMS strings contain multiple direction letters.